### PR TITLE
Add custom test harness and cover orchestrator and worker flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tsx tests/run-tests.ts",
     "orchestrator": "tsx src/orchestrator.ts",
     "worker": "tsx src/worker.ts",
     "mcp": "tsx src/mcp.ts"

--- a/tests/mcp/orchestrator-client.test.ts
+++ b/tests/mcp/orchestrator-client.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, jest } from '../utils/jest-lite.js';
+import type { Job } from '../../src/shared/types.ts';
+import { OrchestratorClient } from '../../src/mcp/orchestrator-client.ts';
+
+const createJobResponse = (overrides: Partial<Job> = {}): Job => ({
+  id: 'job-123',
+  repo_url: 'https://example.com/repo.git',
+  base_ref: 'origin/dev',
+  branch_name: 'codex/sample-branch',
+  worktree_path: '/worktrees/sample',
+  worker_type: 'codex',
+  status: 'pending',
+  spec_json: {
+    goal: 'Implement feature',
+    context_files: ['src/index.ts'],
+  },
+  result_summary: null,
+  conversation_id: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('OrchestratorClient', () => {
+  it('sends spec_json and worker_type when enqueuing Codex jobs', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(createJobResponse()),
+    });
+
+    const client = new OrchestratorClient({
+      baseUrl: 'http://localhost:5555',
+      repoUrl: 'https://example.com/repo.git',
+      worktreeBaseDir: '/worktrees',
+      fetchImpl: fetchMock,
+    });
+
+    const job = await client.enqueueCodexJob({
+      goal: 'Implement feature',
+      context_files: ['src/index.ts'],
+      notes: 'Be mindful of edge cases',
+      base_ref: 'origin/dev',
+    });
+
+    expect(job.id).toBe('job-123');
+    expect(fetchMock.mock.calls.length).toBe(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url instanceof URL).toBe(true);
+    expect((url as URL).pathname).toBe('/jobs');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse((init?.body as string) ?? '{}');
+    expect(body.worker_type).toBe('codex');
+    expect(body.repo_url).toBe('https://example.com/repo.git');
+    expect(body.base_ref).toBe('origin/dev');
+    expect(body.spec_json).toMatchObject({
+      goal: 'Implement feature',
+      context_files: ['src/index.ts'],
+      notes: 'Be mindful of edge cases',
+    });
+  });
+
+  it('includes filters when listing jobs', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([]),
+    });
+
+    const client = new OrchestratorClient({
+      baseUrl: 'http://localhost:5555',
+      repoUrl: 'https://example.com/repo.git',
+      worktreeBaseDir: '/worktrees',
+      fetchImpl: fetchMock,
+    });
+
+    await client.listJobs({ status: 'done', worker_type: 'codex' });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect((url as URL).pathname).toBe('/jobs');
+    expect((url as URL).searchParams.get('status')).toBe('done');
+    expect((url as URL).searchParams.get('worker_type')).toBe('codex');
+  });
+
+  it('requires a job id when fetching job details', async () => {
+    const client = new OrchestratorClient({
+      baseUrl: 'http://localhost:5555',
+      repoUrl: 'https://example.com/repo.git',
+      worktreeBaseDir: '/worktrees',
+      fetchImpl: jest.fn(),
+    });
+
+    try {
+      await client.getJob('');
+      throw new Error('Expected getJob to throw');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toBe('Job ID is required');
+    }
+  });
+
+  it('sends result summary and conversation id when updating job status', async () => {
+    const responseJob = createJobResponse({ status: 'done', result_summary: JSON.stringify({ message: 'ok' }), conversation_id: 'conv-7' });
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(responseJob),
+    });
+
+    const client = new OrchestratorClient({
+      baseUrl: 'http://localhost:5555',
+      repoUrl: 'https://example.com/repo.git',
+      worktreeBaseDir: '/worktrees',
+      fetchImpl: fetchMock,
+    });
+
+    const result = await client.updateJobStatus('job-123', 'done', {
+      result_summary: { message: 'ok' },
+      conversation_id: 'conv-7',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect((url as URL).pathname).toBe('/jobs/job-123/complete');
+    const body = JSON.parse((init?.body as string) ?? '{}');
+    expect(body.status).toBe('done');
+    expect(body.result_summary).toMatchObject({ message: 'ok' });
+    expect(body.conversation_id).toBe('conv-7');
+    expect(result.status).toBe('done');
+  });
+});

--- a/tests/orchestrator/job-model.test.ts
+++ b/tests/orchestrator/job-model.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '../utils/jest-lite.js';
+
+type JobModule = typeof import('../../src/orchestrator/models/job.ts');
+type DbModule = typeof import('../../src/orchestrator/db.ts');
+
+const dbPath = path.join(os.tmpdir(), 'orchestrator-model-tests.sqlite');
+process.env.ORCHESTRATOR_DB_PATH = dbPath;
+
+let dbModule: DbModule;
+let jobModule: JobModule;
+
+const createJobPayload = (overrides: Partial<JobModule['CreateJobInput']> = {}): JobModule['CreateJobInput'] => ({
+  repo_url: 'https://example.com/repo.git',
+  base_ref: 'origin/main',
+  branch_name: 'feature/test',
+  worktree_path: '/tmp/worktree',
+  worker_type: 'codex',
+  status: 'pending',
+  spec_json: {
+    goal: 'Test job',
+    context_files: ['README.md'],
+  },
+  result_summary: null,
+  conversation_id: null,
+  ...overrides,
+});
+
+describe('orchestrator job model', () => {
+  beforeAll(async () => {
+    dbModule = (await import('../../src/orchestrator/db.ts')) as DbModule;
+    dbModule.initDb();
+    jobModule = (await import('../../src/orchestrator/models/job.ts')) as JobModule;
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(dbPath)) {
+      try {
+        fs.rmSync(dbPath);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+
+  beforeEach(() => {
+    const db = dbModule.getDb();
+    db.exec('DELETE FROM jobs');
+  });
+
+  it('claims the oldest pending Codex job and marks it as running', () => {
+    const codexJob = jobModule.createJob(createJobPayload());
+    const otherJob = jobModule.createJob(createJobPayload({ worker_type: 'other', branch_name: 'feature/other' }));
+
+    const claimed = jobModule.claimJob('codex');
+
+    expect(claimed).toBeDefined();
+    expect(claimed?.id).toBe(codexJob.id);
+    expect(claimed?.status).toBe('running');
+
+    const storedCodex = jobModule.getJob(codexJob.id);
+    const storedOther = jobModule.getJob(otherJob.id);
+
+    expect(storedCodex?.status).toBe('running');
+    expect(storedOther?.status).toBe('pending');
+
+    const nextClaim = jobModule.claimJob('codex');
+    expect(nextClaim).toBeNull();
+  });
+
+  it('persists job completion details with status done', () => {
+    const job = jobModule.createJob(createJobPayload());
+
+    const runningJob = jobModule.claimJob('codex');
+    expect(runningJob?.status).toBe('running');
+
+    const summary = { message: 'All good', commit: 'abc123' };
+    jobModule.updateJobStatus(job.id, 'done', summary, 'running', 'conversation-1');
+
+    const updated = jobModule.getJob(job.id);
+    expect(updated?.status).toBe('done');
+    expect(updated?.conversation_id).toBe('conversation-1');
+    expect(updated?.result_summary).toBeDefined();
+    const parsed = JSON.parse(updated!.result_summary!);
+    expect(parsed).toMatchObject(summary);
+  });
+
+  it('throws when updating a job with unexpected current status', () => {
+    const job = jobModule.createJob(createJobPayload());
+
+    const update = () => jobModule.updateJobStatus(job.id, 'failed', { error: 'boom' }, 'running');
+
+    expect(update).toThrow();
+  });
+});

--- a/tests/orchestrator/jobs-routes.test.ts
+++ b/tests/orchestrator/jobs-routes.test.ts
@@ -1,0 +1,113 @@
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from '../utils/jest-lite.js';
+
+const dbModulePromise = import('../../src/orchestrator/db.ts');
+const jobModulePromise = import('../../src/orchestrator/models/job.ts');
+const serverModulePromise = import('../../src/orchestrator/server.ts');
+
+const createJobPayload = (overrides: Record<string, unknown> = {}) => ({
+  repo_url: 'https://example.com/repo.git',
+  base_ref: 'origin/main',
+  branch_name: 'feature/http-test',
+  worktree_path: '/tmp/worktree-http',
+  worker_type: 'codex',
+  spec_json: {
+    goal: 'Verify route behaviour',
+    context_files: ['README.md'],
+  },
+  ...overrides,
+});
+
+describe('orchestrator job routes', () => {
+  let dbModule: typeof import('../../src/orchestrator/db.ts');
+  let jobModule: typeof import('../../src/orchestrator/models/job.ts');
+  let serverModule: typeof import('../../src/orchestrator/server.ts');
+  let server: http.Server | null = null;
+  let baseUrl: string = '';
+
+  beforeAll(async () => {
+    dbModule = await dbModulePromise;
+    jobModule = await jobModulePromise;
+    serverModule = await serverModulePromise;
+    dbModule.initDb();
+  });
+
+  beforeEach(() => {
+    const db = dbModule.getDb();
+    db.exec('DELETE FROM jobs');
+
+    const app = serverModule.createApp();
+    server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+      server = null;
+    }
+  });
+
+  it('claims pending Codex jobs without touching other worker types', async () => {
+    const createResponse = await fetch(`${baseUrl}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(createJobPayload()),
+    });
+    expect(createResponse.status).toBe(201);
+    const created = await createResponse.json();
+
+    const otherResponse = await fetch(`${baseUrl}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(createJobPayload({ worker_type: 'other', branch_name: 'feature/other-worker' })),
+    });
+    expect(otherResponse.status).toBe(201);
+
+    const claimResponse = await fetch(`${baseUrl}/jobs/claim?worker_type=codex`, { method: 'POST' });
+    expect(claimResponse.status).toBe(200);
+    const claimed = await claimResponse.json();
+    expect(claimed.id).toBe(created.id);
+    expect(claimed.status).toBe('running');
+
+    const stored = jobModule.getJob(created.id);
+    expect(stored?.status).toBe('running');
+
+    const secondClaim = await fetch(`${baseUrl}/jobs/claim?worker_type=codex`, { method: 'POST' });
+    expect(secondClaim.status).toBe(404);
+  });
+
+  it('completes jobs and persists status transitions through HTTP API', async () => {
+    const createResponse = await fetch(`${baseUrl}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(createJobPayload()),
+    });
+    expect(createResponse.status).toBe(201);
+    const created = await createResponse.json();
+
+    const claimResponse = await fetch(`${baseUrl}/jobs/claim?worker_type=codex`, { method: 'POST' });
+    expect(claimResponse.status).toBe(200);
+
+    const completionSummary = { message: 'Completed via HTTP', commit: 'def456' };
+    const completeResponse = await fetch(`${baseUrl}/jobs/${created.id}/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done', result_summary: completionSummary, conversation_id: 'conv-42' }),
+    });
+    expect(completeResponse.status).toBe(200);
+    const completedJob = await completeResponse.json();
+
+    expect(completedJob.status).toBe('done');
+    expect(completedJob.result_summary).toBeDefined();
+    const parsedSummary = JSON.parse(completedJob.result_summary);
+    expect(parsedSummary).toMatchObject(completionSummary);
+
+    const stored = jobModule.getJob(created.id);
+    expect(stored?.status).toBe('done');
+    expect(stored?.conversation_id).toBe('conv-42');
+  });
+});

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { clearSuites, runAllSuites } from './utils/jest-lite.js';
+
+const isTestFile = (filePath: string): boolean => /\.test\.ts$/.test(filePath);
+
+const collectTestFiles = (dir: string, results: string[]): void => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.git')) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectTestFiles(fullPath, results);
+    } else if (entry.isFile() && isTestFile(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+};
+
+const main = async () => {
+  const testsDir = path.resolve(path.dirname(new URL(import.meta.url).pathname));
+  const repoRoot = path.resolve(testsDir, '..');
+  const testFiles: string[] = [];
+  collectTestFiles(testsDir, testFiles);
+  collectTestFiles(path.join(repoRoot, 'src'), testFiles);
+
+  if (testFiles.length === 0) {
+    console.log('No test files found.');
+    return;
+  }
+
+  clearSuites();
+
+  testFiles.sort();
+
+  for (const file of testFiles) {
+    const fileUrl = pathToFileURL(file);
+    await import(fileUrl.href);
+  }
+
+  const { failed, passed, failures } = await runAllSuites();
+  console.log(`\nTest summary: ${passed} passed, ${failed} failed.`);
+  if (failures.length) {
+    for (const failure of failures) {
+      const location = failure.suitePath ? `${failure.suitePath} > ${failure.testName}` : failure.testName;
+      const message = failure.error instanceof Error ? failure.error.stack ?? failure.error.message : String(failure.error);
+      console.error(`\n${location}\n${message}`);
+    }
+    process.exitCode = 1;
+  }
+};
+
+await main();

--- a/tests/utils/jest-lite.ts
+++ b/tests/utils/jest-lite.ts
@@ -1,0 +1,440 @@
+import assert from 'node:assert/strict';
+
+export type Hook = () => void | Promise<void>;
+export type TestFn = () => void | Promise<void>;
+
+interface TestCase {
+  name: string;
+  fn: TestFn;
+}
+
+interface Suite {
+  name: string;
+  tests: TestCase[];
+  beforeAll: Hook[];
+  afterAll: Hook[];
+  beforeEach: Hook[];
+  afterEach: Hook[];
+  children: Suite[];
+  parent?: Suite;
+}
+
+const globalSuite: Suite = {
+  name: '(root)',
+  tests: [],
+  beforeAll: [],
+  afterAll: [],
+  beforeEach: [],
+  afterEach: [],
+  children: [],
+};
+
+let currentSuite: Suite = globalSuite;
+
+const runInSuite = (suite: Suite, fn: () => void) => {
+  const previous = currentSuite;
+  currentSuite = suite;
+  try {
+    fn();
+  } finally {
+    currentSuite = previous;
+  }
+};
+
+export const describe = (name: string, fn: () => void): void => {
+  const suite: Suite = {
+    name,
+    tests: [],
+    beforeAll: [],
+    afterAll: [],
+    beforeEach: [],
+    afterEach: [],
+    children: [],
+    parent: currentSuite,
+  };
+  currentSuite.children.push(suite);
+  runInSuite(suite, fn);
+};
+
+export const test = (name: string, fn: TestFn): void => {
+  currentSuite.tests.push({ name, fn });
+};
+
+export const it = test;
+
+export const beforeAll = (fn: Hook): void => {
+  currentSuite.beforeAll.push(fn);
+};
+
+export const afterAll = (fn: Hook): void => {
+  currentSuite.afterAll.push(fn);
+};
+
+export const beforeEach = (fn: Hook): void => {
+  currentSuite.beforeEach.push(fn);
+};
+
+export const afterEach = (fn: Hook): void => {
+  currentSuite.afterEach.push(fn);
+};
+
+type MockCall = { args: unknown[]; result?: { type: 'return' | 'throw'; value: unknown } };
+
+type MockState = {
+  impl: (...args: unknown[]) => unknown;
+  queue: Array<(...args: unknown[]) => unknown>;
+};
+
+interface MockFunction<T extends (...args: any[]) => any> {
+  (...args: Parameters<T>): ReturnType<T>;
+  mock: {
+    calls: Array<Parameters<T>>;
+    results: Array<{ type: 'return' | 'throw'; value: ReturnType<T> | unknown }>;
+  };
+  mockImplementation(fn: T): MockFunction<T>;
+  mockImplementationOnce(fn: T): MockFunction<T>;
+  mockReturnValue(value: ReturnType<T>): MockFunction<T>;
+  mockResolvedValue(value: Awaited<ReturnType<T>>): MockFunction<T>;
+  mockRejectedValue(error: unknown): MockFunction<T>;
+  mockClear(): void;
+  mockReset(): void;
+  mockRestore?(): void;
+}
+
+const createMock = <T extends (...args: any[]) => any>(impl?: T): MockFunction<T> => {
+  const state: MockState = {
+    impl: impl ?? (((..._args: unknown[]) => undefined) as (...args: unknown[]) => unknown),
+    queue: [],
+  };
+
+  const calls: Array<Parameters<T>> = [];
+  const results: Array<{ type: 'return' | 'throw'; value: unknown }> = [];
+
+  const mockFn = ((...args: Parameters<T>) => {
+    let fnToCall = state.impl;
+    if (state.queue.length) {
+      fnToCall = state.queue.shift()!;
+    }
+    try {
+      const value = fnToCall(...args) as ReturnType<T>;
+      calls.push(args);
+      results.push({ type: 'return', value });
+      return value;
+    } catch (error) {
+      calls.push(args);
+      results.push({ type: 'throw', value: error });
+      throw error;
+    }
+  }) as MockFunction<T>;
+
+  mockFn.mock = { calls, results };
+
+  mockFn.mockImplementation = (fn: T) => {
+    state.impl = fn;
+    return mockFn;
+  };
+
+  mockFn.mockImplementationOnce = (fn: T) => {
+    state.queue.push(fn);
+    return mockFn;
+  };
+
+  mockFn.mockReturnValue = (value: ReturnType<T>) => {
+    state.impl = (() => value) as unknown as T;
+    return mockFn;
+  };
+
+  mockFn.mockResolvedValue = (value: Awaited<ReturnType<T>>) => {
+    state.impl = ((..._args: unknown[]) => Promise.resolve(value)) as unknown as T;
+    return mockFn;
+  };
+
+  mockFn.mockRejectedValue = (error: unknown) => {
+    state.impl = ((..._args: unknown[]) => Promise.reject(error)) as unknown as T;
+    return mockFn;
+  };
+
+  mockFn.mockClear = () => {
+    calls.length = 0;
+    results.length = 0;
+  };
+
+  mockFn.mockReset = () => {
+    mockFn.mockClear();
+    state.impl = (((..._args: unknown[]) => undefined) as (...args: unknown[]) => unknown);
+    state.queue = [];
+  };
+
+  return mockFn;
+};
+
+const spyOn = <T extends object, K extends keyof T>(object: T, method: K): MockFunction<T[K] extends (...args: any[]) => any ? T[K] : never> => {
+  const original = object[method];
+  if (typeof original !== 'function') {
+    throw new Error(`Cannot spy on non-function property ${String(method)}`);
+  }
+  const mock = createMock(original as (...args: any[]) => unknown) as MockFunction<any>;
+  const replacement = function (this: unknown, ...args: unknown[]) {
+    return mock.apply(this, args);
+  };
+  Object.defineProperty(object, method, {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: replacement,
+  });
+  mock.mockRestore = () => {
+    Object.defineProperty(object, method, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: original,
+    });
+  };
+  return mock;
+};
+
+const formatValue = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+class Expectation<T> {
+  constructor(private readonly actual: T, private readonly negate = false) {}
+
+  private check(condition: boolean, message: string): void {
+    const pass = this.negate ? !condition : condition;
+    if (!pass) {
+      throw new Error(message);
+    }
+  }
+
+  get not(): Expectation<T> {
+    return new Expectation(this.actual, !this.negate);
+  }
+
+  toBe(expected: T): void {
+    this.check(Object.is(this.actual, expected), `Expected ${formatValue(this.actual)} ${this.negate ? 'not ' : ''}to be ${formatValue(expected)}`);
+  }
+
+  toEqual(expected: unknown): void {
+    try {
+      assert.deepEqual(this.actual, expected);
+      if (this.negate) {
+        throw new Error('Expected values to not be equal');
+      }
+    } catch (error) {
+      if (!this.negate) {
+        throw error instanceof Error ? error : new Error(String(error));
+      }
+    }
+  }
+
+  toStrictEqual(expected: unknown): void {
+    try {
+      assert.deepStrictEqual(this.actual, expected);
+      if (this.negate) {
+        throw new Error('Expected values to not be strictly equal');
+      }
+    } catch (error) {
+      if (!this.negate) {
+        throw error instanceof Error ? error : new Error(String(error));
+      }
+    }
+  }
+
+  toMatchObject(expected: Record<string, unknown>): void {
+    if (typeof this.actual !== 'object' || this.actual === null) {
+      throw new Error('Actual value is not an object');
+    }
+    const actualRecord = this.actual as Record<string, unknown>;
+    for (const [key, value] of Object.entries(expected)) {
+      if (!(key in actualRecord)) {
+        if (!this.negate) {
+          throw new Error(`Expected object to have key ${key}`);
+        }
+        return;
+      }
+      try {
+        assert.deepStrictEqual(actualRecord[key], value);
+        if (this.negate) {
+          throw new Error(`Expected property ${key} to not match`);
+        }
+      } catch (error) {
+        if (!this.negate) {
+          throw error instanceof Error ? error : new Error(String(error));
+        }
+      }
+    }
+  }
+
+  toBeNull(): void {
+    this.check(this.actual === null, `Expected ${formatValue(this.actual)} ${this.negate ? 'not ' : ''}to be null`);
+  }
+
+  toBeDefined(): void {
+    this.check(this.actual !== undefined, `Expected value ${this.negate ? 'not ' : ''}to be defined`);
+  }
+
+  toBeTruthy(): void {
+    this.check(Boolean(this.actual), `Expected ${formatValue(this.actual)} ${this.negate ? 'not ' : ''}to be truthy`);
+  }
+
+  toContain(expected: unknown): void {
+    if (typeof this.actual === 'string') {
+      this.check(this.actual.includes(String(expected)), `Expected string to ${this.negate ? 'not ' : ''}contain ${String(expected)}`);
+      return;
+    }
+    if (Array.isArray(this.actual)) {
+      this.check(this.actual.includes(expected), `Expected array to ${this.negate ? 'not ' : ''}contain ${formatValue(expected)}`);
+      return;
+    }
+    throw new Error('Actual value does not support containment checks');
+  }
+
+  toHaveLength(expected: number): void {
+    if (this.actual && typeof (this.actual as any).length === 'number') {
+      this.check((this.actual as any).length === expected, `Expected length ${this.negate ? 'not ' : ''}to be ${expected} but received ${(this.actual as any).length}`);
+      return;
+    }
+    throw new Error('Actual value does not have length property');
+  }
+
+  toThrow(expected?: RegExp | string): void {
+    if (typeof this.actual !== 'function') {
+      throw new Error('Actual value is not a function');
+    }
+    let threw = false;
+    try {
+      (this.actual as unknown as () => unknown)();
+    } catch (error) {
+      threw = true;
+      if (expected instanceof RegExp) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.check(expected.test(message), `Expected error message to match ${expected}, received ${message}`);
+      } else if (typeof expected === 'string') {
+        const message = error instanceof Error ? error.message : String(error);
+        this.check(message.includes(expected), `Expected error message to include ${expected}, received ${message}`);
+      }
+    }
+    this.check(threw, 'Expected function to throw');
+  }
+}
+
+export const expect = <T>(actual: T): Expectation<T> => new Expectation(actual);
+
+export const jest = {
+  fn: createMock,
+  spyOn,
+};
+
+export const getRootSuites = (): Suite[] => globalSuite.children;
+
+export const clearSuites = (): void => {
+  globalSuite.children = [];
+  globalSuite.tests = [];
+  globalSuite.beforeAll = [];
+  globalSuite.afterAll = [];
+  globalSuite.beforeEach = [];
+  globalSuite.afterEach = [];
+  currentSuite = globalSuite;
+};
+
+const gatherBeforeEach = (suite: Suite): Hook[] => {
+  const hooks: Hook[] = [];
+  let current: Suite | undefined = suite;
+  while (current) {
+    hooks.unshift(...current.beforeEach);
+    current = current.parent;
+  }
+  return hooks;
+};
+
+const gatherAfterEach = (suite: Suite): Hook[] => {
+  const hooks: Hook[] = [];
+  let current: Suite | undefined = suite;
+  while (current) {
+    hooks.push(...current.afterEach);
+    current = current.parent;
+  }
+  return hooks;
+};
+
+interface TestFailure {
+  suitePath: string;
+  testName: string;
+  error: unknown;
+}
+
+const runHooks = async (hooks: Hook[], reverse = false): Promise<void> => {
+  const ordered = reverse ? [...hooks].reverse() : hooks;
+  for (const hook of ordered) {
+    await hook();
+  }
+};
+
+const suiteNamePath = (suite: Suite): string[] => {
+  const names: string[] = [];
+  let current: Suite | undefined = suite;
+  while (current && current !== globalSuite) {
+    names.unshift(current.name);
+    current = current.parent;
+  }
+  return names;
+};
+
+const runSuite = async (suite: Suite, depth: number, failures: TestFailure[], stats: { passed: number; failed: number }): Promise<void> => {
+  const indent = '  '.repeat(depth);
+  if (suite !== globalSuite) {
+    console.log(`${indent}${suite.name}`);
+  }
+  await runHooks(suite.beforeAll);
+  for (const testCase of suite.tests) {
+    const beforeEachHooks = gatherBeforeEach(suite);
+    const afterEachHooks = gatherAfterEach(suite);
+    const testIndent = '  '.repeat(suite === globalSuite ? depth : depth + 1);
+    try {
+      await runHooks(beforeEachHooks);
+      await testCase.fn();
+      console.log(`${testIndent}✓ ${testCase.name}`);
+      stats.passed += 1;
+    } catch (error) {
+      failures.push({ suitePath: suiteNamePath(suite).join(' > '), testName: testCase.name, error });
+      console.log(`${testIndent}✗ ${testCase.name}`);
+      stats.failed += 1;
+    } finally {
+      try {
+        await runHooks(afterEachHooks);
+      } catch (error) {
+        failures.push({ suitePath: suiteNamePath(suite).join(' > '), testName: `${testCase.name} (afterEach)`, error });
+        console.log(`${testIndent}✗ ${testCase.name} (afterEach)`);
+        stats.failed += 1;
+      }
+    }
+  }
+  for (const child of suite.children) {
+    await runSuite(child, suite === globalSuite ? depth : depth + 1, failures, stats);
+  }
+  await runHooks(suite.afterAll, true);
+};
+
+export const runAllSuites = async (): Promise<{ failed: number; passed: number; failures: TestFailure[] }> => {
+  const suites = getRootSuites();
+  const failures: TestFailure[] = [];
+  const stats = { passed: 0, failed: 0 };
+  if (!suites.length && !globalSuite.tests.length) {
+    console.log('No tests found.');
+    return { failed: 0, passed: 0, failures: [] };
+  }
+  if (globalSuite.tests.length) {
+    await runSuite(globalSuite, 0, failures, stats);
+  }
+  for (const suite of suites) {
+    await runSuite(suite, 0, failures, stats);
+  }
+  return { ...stats, failures };
+};
+

--- a/tests/worker/codex-worker.test.ts
+++ b/tests/worker/codex-worker.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, jest } from '../utils/jest-lite.js';
+import type { Job } from '../../src/shared/types.ts';
+import { CodexWorker } from '../../src/worker/codex-worker.ts';
+
+const createJob = (overrides: Partial<Job> = {}): Job => ({
+  id: 'job-1',
+  repo_url: '/repos/source',
+  base_ref: 'origin/main',
+  branch_name: 'feature/task',
+  worktree_path: '/worktrees/job-1',
+  worker_type: 'codex',
+  status: 'pending',
+  spec_json: {
+    goal: 'Do something',
+    context_files: [],
+  },
+  result_summary: null,
+  conversation_id: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('CodexWorker handleJob', () => {
+  it('reports successful Codex execution as done', async () => {
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const createWorktree = jest.fn().mockResolvedValue({
+      path: '/tmp/worktree',
+      branchName: 'feature/task',
+      cleanup,
+    });
+    const executeCodex = jest.fn().mockResolvedValue({ success: true, conversationId: 'conv-123' });
+    const completeJob = jest.fn().mockResolvedValue(undefined);
+
+    const worker = new CodexWorker({
+      fetchImpl: jest.fn(),
+      createWorktree,
+      executeCodex,
+    });
+
+    (worker as any).ensureRepoPath = jest.fn().mockResolvedValue('/tmp/repo');
+    (worker as any).resolveWorktreePath = jest.fn().mockResolvedValue('/tmp/worktree');
+    (worker as any).commitChanges = jest.fn().mockResolvedValue('abc123');
+    (worker as any).pushBranch = jest.fn().mockResolvedValue(undefined);
+    (worker as any).runTests = jest.fn().mockResolvedValue(true);
+    (worker as any).completeJob = completeJob;
+
+    await (worker as any).handleJob(createJob());
+
+    expect(createWorktree.mock.calls.length).toBe(1);
+    expect(executeCodex.mock.calls[0][1]).toMatchObject({ goal: 'Do something' });
+    expect(completeJob.mock.calls.length).toBe(1);
+    const [jobId, status, summary, conversationId] = completeJob.mock.calls[0];
+    expect(jobId).toBe('job-1');
+    expect(status).toBe('done');
+    expect(conversationId).toBe('conv-123');
+    const codexSummary = summary.codex as Record<string, unknown>;
+    expect(codexSummary.success).toBe(true);
+    expect(codexSummary.awaiting_input).toBe(false);
+    expect(codexSummary.conversation_id).toBe('conv-123');
+    expect(summary.tests).toBe('passed');
+    expect(summary.commit_hash).toBe('abc123');
+    expect(summary.pushed).toBe(true);
+    expect(cleanup.mock.calls.length).toBe(1);
+  });
+
+  it('reports failures when Codex execution fails', async () => {
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const createWorktree = jest.fn().mockResolvedValue({
+      path: '/tmp/worktree',
+      branchName: 'feature/task',
+      cleanup,
+    });
+    const executeCodex = jest.fn().mockResolvedValue({ success: false, error: 'Codex crashed', conversationId: 'conv-fail' });
+    const completeJob = jest.fn().mockResolvedValue(undefined);
+
+    const worker = new CodexWorker({ fetchImpl: jest.fn(), createWorktree, executeCodex });
+
+    (worker as any).ensureRepoPath = jest.fn().mockResolvedValue('/tmp/repo');
+    (worker as any).resolveWorktreePath = jest.fn().mockResolvedValue('/tmp/worktree');
+    (worker as any).commitChanges = jest.fn().mockResolvedValue(undefined);
+    (worker as any).pushBranch = jest.fn().mockResolvedValue(undefined);
+    (worker as any).runTests = jest.fn().mockResolvedValue(undefined);
+    (worker as any).completeJob = completeJob;
+
+    await (worker as any).handleJob(createJob());
+
+    expect(completeJob.mock.calls.length).toBe(1);
+    const [, status, summary, conversationId] = completeJob.mock.calls[0];
+    expect(status).toBe('failed');
+    expect(conversationId).toBe('conv-fail');
+    expect(summary.error).toBe('Codex crashed');
+    const codexSummary = summary.codex as Record<string, unknown>;
+    expect(codexSummary.success).toBe(false);
+    expect(codexSummary.awaiting_input).toBe(false);
+    expect(codexSummary.conversation_id).toBe('conv-fail');
+    expect(cleanup.mock.calls.length).toBe(0);
+  });
+
+  it('marks jobs as awaiting input when Codex requests more information', async () => {
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const createWorktree = jest.fn().mockResolvedValue({
+      path: '/tmp/worktree',
+      branchName: 'feature/task',
+      cleanup,
+    });
+    const executeCodex = jest
+      .fn()
+      .mockResolvedValue({ success: false, awaitingInput: true, error: 'Need clarification', conversationId: 'conv-await' });
+    const completeJob = jest.fn().mockResolvedValue(undefined);
+
+    const worker = new CodexWorker({ fetchImpl: jest.fn(), createWorktree, executeCodex });
+
+    (worker as any).ensureRepoPath = jest.fn().mockResolvedValue('/tmp/repo');
+    (worker as any).resolveWorktreePath = jest.fn().mockResolvedValue('/tmp/worktree');
+    (worker as any).commitChanges = jest.fn(() => {
+      throw new Error('commitChanges should not be called when awaiting input');
+    });
+    (worker as any).pushBranch = jest.fn(() => {
+      throw new Error('pushBranch should not be called when awaiting input');
+    });
+    (worker as any).runTests = jest.fn(() => {
+      throw new Error('runTests should not be called when awaiting input');
+    });
+    (worker as any).completeJob = completeJob;
+
+    await (worker as any).handleJob(createJob());
+
+    expect(completeJob.mock.calls.length).toBe(1);
+    const [, status, summary, conversationId] = completeJob.mock.calls[0];
+    expect(status).toBe('awaiting_input');
+    expect(conversationId).toBe('conv-await');
+    const codexSummary = summary.codex as Record<string, unknown>;
+    expect(codexSummary.awaiting_input).toBe(true);
+    expect(codexSummary.conversation_id).toBe('conv-await');
+    expect(summary.message).toBe('Codex is awaiting additional input before proceeding.');
+    expect(cleanup.mock.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a lightweight Jest-style runner to execute TypeScript test files without external dependencies
- cover orchestrator models and routes for job claiming, completion, and worker-type filtering
- exercise Codex worker and MCP client flows to validate status reporting and HTTP payloads

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918214567e08328ac8b1cc79c0cf43b)