### PR TITLE
feat: 複数jobを1つのfeatureとして束ねるfeature機能を追加

### DIFF
--- a/src/mcp/orchestrator-client.ts
+++ b/src/mcp/orchestrator-client.ts
@@ -67,11 +67,14 @@ export interface EnqueueCodexJobArgs {
   context_files: string[];
   notes?: string;
   base_ref?: string;
+  feature_id?: string;
+  feature_part?: string;
 }
 
 export interface ListJobsFilter {
   status?: JobStatus;
   worker_type?: string;
+  feature_id?: string;
 }
 
 export interface CleanupJobsOptions {
@@ -125,6 +128,8 @@ export class OrchestratorClient {
       worktree_path: metadata.worktreePath,
       worker_type: WORKER_TYPE_CODEX,
       spec_json: specPayload,
+      feature_id: args.feature_id,
+      feature_part: args.feature_part,
     };
 
     return this.request<Job>('/jobs', {
@@ -137,6 +142,7 @@ export class OrchestratorClient {
     const query = toQueryParams(filter ? {
       status: filter.status,
       worker_type: filter.worker_type,
+      feature_id: filter.feature_id,
     } : undefined);
     return this.request<Job[]>('/jobs', undefined, query ?? undefined);
   }

--- a/src/orchestrator/db.ts
+++ b/src/orchestrator/db.ts
@@ -38,6 +38,8 @@ export const runMigrations = (): void => {
       branch_name TEXT NOT NULL,
       worktree_path TEXT NOT NULL,
       worker_type TEXT NOT NULL,
+      feature_id TEXT,
+      feature_part TEXT,
       status TEXT NOT NULL,
       spec_json TEXT NOT NULL,
       result_summary TEXT,
@@ -52,9 +54,19 @@ export const runMigrations = (): void => {
 
   const columns = db.prepare(`PRAGMA table_info(jobs)`).all() as Array<{ name: string }>;
   const hasConversationId = columns.some((column) => column.name === 'conversation_id');
+  const hasFeatureId = columns.some((column) => column.name === 'feature_id');
+  const hasFeaturePart = columns.some((column) => column.name === 'feature_part');
   if (!hasConversationId) {
     db.exec('ALTER TABLE jobs ADD COLUMN conversation_id TEXT');
   }
+  if (!hasFeatureId) {
+    db.exec('ALTER TABLE jobs ADD COLUMN feature_id TEXT');
+  }
+  if (!hasFeaturePart) {
+    db.exec('ALTER TABLE jobs ADD COLUMN feature_part TEXT');
+  }
+
+  db.exec('CREATE INDEX IF NOT EXISTS idx_jobs_feature_id ON jobs(feature_id)');
 };
 
 export const initDb = (): BetterSqlite3Database => {

--- a/src/orchestrator/routes/features.ts
+++ b/src/orchestrator/routes/features.ts
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+
+import { listJobs } from '../models/job.js';
+import type { Job } from '../../shared/types.js';
+
+export const router = Router();
+
+router.get('/', (_req, res) => {
+  try {
+    const allJobs = listJobs();
+    const featuredJobs = allJobs.filter((job) => job.feature_id !== null);
+
+    const featureMap = new Map<string, Job[]>();
+    for (const job of featuredJobs) {
+      if (!job.feature_id) continue;
+      if (!featureMap.has(job.feature_id)) {
+        featureMap.set(job.feature_id, []);
+      }
+      featureMap.get(job.feature_id)!.push(job);
+    }
+
+    const features = Array.from(featureMap.entries()).map(([feature_id, jobs]) => {
+      const statusCounts = jobs.reduce<Record<string, number>>((acc, job) => {
+        acc[job.status] = (acc[job.status] || 0) + 1;
+        return acc;
+      }, {});
+
+      const parts = [...new Set(jobs.map((j) => j.feature_part).filter((part): part is string => part !== null))];
+      const sortedByUpdated = [...jobs].sort(
+        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      );
+
+      return {
+        feature_id,
+        job_count: jobs.length,
+        status_counts: statusCounts,
+        parts,
+        created_at: jobs[0]?.created_at ?? null,
+        updated_at: sortedByUpdated[0]?.updated_at ?? null,
+      };
+    });
+
+    res.json(features);
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+router.get('/:feature_id', (req, res) => {
+  try {
+    const { feature_id } = req.params;
+    const jobs = listJobs({ feature_id });
+
+    if (jobs.length === 0) {
+      return res.status(404).json({ error: 'Feature not found' });
+    }
+
+    const jobSummaries = jobs.map((job) => ({
+      id: job.id,
+      status: job.status,
+      feature_part: job.feature_part,
+      branch_name: job.branch_name,
+      created_at: job.created_at,
+      updated_at: job.updated_at,
+      spec_json: { goal: job.spec_json.goal },
+    }));
+
+    res.json({
+      feature_id,
+      jobs: jobSummaries,
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});

--- a/src/orchestrator/server.ts
+++ b/src/orchestrator/server.ts
@@ -3,6 +3,7 @@ import { ZodError } from 'zod';
 
 import { appConfig } from '../shared/config.js';
 import jobsRouter from './routes/jobs.js';
+import { router as featuresRouter } from './routes/features.js';
 import { initDb } from './db.js';
 
 export const createApp = () => {
@@ -10,6 +11,7 @@ export const createApp = () => {
 
   app.use(express.json());
   app.use('/jobs', jobsRouter);
+  app.use('/features', featuresRouter);
 
   app.use((req, res) => {
     res.status(404).json({ error: 'Not found' });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,6 +15,8 @@ export interface Job {
   branch_name: string;
   worktree_path: string;
   worker_type: string;
+  feature_id?: string | null;
+  feature_part?: string | null;
   status: JobStatus;
   spec_json: SpecJson;
   result_summary: string | null;


### PR DESCRIPTION
## 概要

複数のCodex jobを論理的にグループ化できるように、Job型に`feature_id`と`feature_part`メタデータを追加しました。

## 追加された機能

### データモデル
- `Job`型に以下のフィールドを追加：
  - `feature_id?: string | null` - feature識別子（例: "comment-system", "user-auth"）
  - `feature_part?: string | null` - 役割ラベル（例: "backend", "frontend", "migration"）

### API エンドポイント
- **POST /jobs** - feature_id/feature_partを受け付け
- **GET /jobs?feature_id=xxx** - feature_idでフィルタ可能
- **GET /features** - すべてのfeature一覧（ステータス集計付き）✨新規
- **GET /features/:feature_id** - 特定featureのジョブ一覧✨新規

### MCP Tools
- **enqueue_codex_job** - feature_id/feature_partパラメータを追加
- **list_jobs** - feature_idフィルタを追加

## 主な変更ファイル

- `src/shared/types.ts` - Job型定義
- `src/orchestrator/db.ts` - DB schema + マイグレーション
- `src/orchestrator/models/job.ts` - CRUD操作
- `src/orchestrator/routes/jobs.ts` - HTTP API
- `src/orchestrator/routes/features.ts` - Feature API（新規）
- `src/mcp/orchestrator-client.ts` - MCP client
- `src/mcp/tools/job-tools.ts` - MCP tools
- テスト3ファイル

## DBマイグレーション

既存DBに対して初回起動時に自動マイグレーションが実行されます：
- `ALTER TABLE jobs ADD COLUMN feature_id TEXT`
- `ALTER TABLE jobs ADD COLUMN feature_part TEXT`
- `CREATE INDEX idx_jobs_feature_id ON jobs(feature_id)`

既存のジョブはすべて `feature_id=null`, `feature_part=null` となり、従来どおり動作します。

## ユースケース

### 1. 大きな機能を複数jobに分割
```typescript
// backend job
enqueueCodexJob({
  goal: "コメント機能のバックエンドAPI実装",
  context_files: ["src/api/comments.ts"],
  feature_id: "comment-system",
  feature_part: "backend"
});

// frontend job
enqueueCodexJob({
  goal: "コメント機能のフロントエンド実装",
  context_files: ["src/components/Comment.tsx"],
  feature_id: "comment-system",
  feature_part: "frontend"
});

// 進捗確認
GET /features/comment-system
```

### 2. 複数リポジトリにまたがる機能開発
```typescript
// リポジトリA: APIサーバー
enqueueCodexJob({
  feature_id: "search-v2",
  feature_part: "api-server"
});

// リポジトリB: Webフロント
enqueueCodexJob({
  feature_id: "search-v2",
  feature_part: "web-frontend"
});

// Feature全体の進捗確認
GET /features/search-v2
```

## テスト

✅ すべてのテストがpass（25 passed, 0 failed）
- feature付きジョブの作成・取得
- feature情報なしのジョブ（後方互換性）
- feature_idフィルタの動作
- 空文字列のバリデーション
- MCP層でのfeature伝搬

## 受け入れ基準

- [x] TypeScript type check pass
- [x] npm test pass（25 tests）
- [x] 既存ジョブが従来どおり動作（後方互換性）
- [x] DBマイグレーションが自動実行される
- [x] feature_idでフィルタできる
- [x] Feature APIで集約情報を取得できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)