### PR TITLE
feat: MCPサーバー起動時にOrchestrator/Workerも同時起動

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -55,6 +55,9 @@ const registerSignalHandlers = () => {
 const main = async (): Promise<void> => {
   registerSignalHandlers();
 
+  // Redirect all console.log to stderr to keep MCP stdio transport clean
+  console.log = (...args) => console.error(...args);
+
   try {
     // 1. Start Orchestrator (HTTP API + SQLite)
     orchestratorServer = startOrchestrator();


### PR DESCRIPTION
## Summary
- `npm run mcp` だけでOrchestrator、Worker、MCP Serverが全て起動するように変更
- シグナルハンドリング（SIGINT/SIGTERM）でグレースフル終了を実装

## Test plan
- [x] 型チェック通過
- [x] 全テスト通過（48件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)