### PR TITLE
Add Node types to tsconfig for backend build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add "types": ["node"] to the root tsconfig so backend builds pick up Node ambient types when no other type libs are present

## Testing
- npm run build (UI build still emits existing Svelte a11y a11y warnings)